### PR TITLE
Function names collision - Jiterpretter

### DIFF
--- a/MonacoEditorComponent/CodeEditor/CodeEditor.cs
+++ b/MonacoEditorComponent/CodeEditor/CodeEditor.cs
@@ -85,7 +85,7 @@ namespace Monaco
             {
                 if (ReadOnly != options.ReadOnly) options.ReadOnly = ReadOnly;
             }
-            await InvokeScriptAsync("updateOptions", options);
+            await InvokeScriptAsync("updateMonacoOptions", options);
         }
 
         private void CodeEditor_Loaded(object sender, RoutedEventArgs e)

--- a/MonacoEditorComponent/ts-helpermethods/otherScriptsToBeOrganized.ts
+++ b/MonacoEditorComponent/ts-helpermethods/otherScriptsToBeOrganized.ts
@@ -98,7 +98,7 @@ var getOptions = function (): monaco.editor.IEditorOptions {
     return {};
 };
 
-var updateOptions = function (opt: monaco.editor.IEditorOptions) {
+var updateMonacoOptions = function (opt: monaco.editor.IEditorOptions) {
     if (opt != null && typeof opt === "object") {
         editor.updateOptions(opt);
     }


### PR DESCRIPTION
Since the bootstrapper were upgraded, Uno Monaco Editor is not abble to set some options. 
The reason why is that we have a collision between the function updateOption from Monaco and another with the same name introduced by the recent updates.