### PR TITLE
fix: Fix Monaco not working with updated lifecycle in NPE

### DIFF
--- a/MonacoEditorComponent/CodeEditor/CodeEditor.Events.cs
+++ b/MonacoEditorComponent/CodeEditor/CodeEditor.Events.cs
@@ -43,7 +43,10 @@ namespace Monaco
 
         private ThemeListener _themeListener;
 
-        private void WebView_DOMContentLoaded(ICodeEditorPresenter sender, object args)
+        private void WebView_DOMContentLoaded(object sender, RoutedEventArgs args)
+            => WebView_DOMContentLoaded();
+
+        private void WebView_DOMContentLoaded()
         {
             #if DEBUG
             Debug.WriteLine("DOM Content Loaded");

--- a/MonacoEditorComponent/CodeEditor/CodeEditor.cs
+++ b/MonacoEditorComponent/CodeEditor/CodeEditor.cs
@@ -102,6 +102,7 @@ namespace Monaco
                 Markers.VectorChanged += Markers_VectorChanged;
 
                 _view.NewWindowRequested += WebView_NewWindowRequested;
+                _view.Loaded += WebView_DOMContentLoaded;
 
                 Debug.WriteLine("Setting initialized - true");
                 _initialized = true;
@@ -121,9 +122,9 @@ namespace Monaco
             if (_view != null)
             {
                 _view.NavigationStarting -= WebView_NavigationStarting;
-                _view.DOMContentLoaded -= WebView_DOMContentLoaded;
                 _view.NavigationCompleted -= WebView_NavigationCompleted;
                 _view.NewWindowRequested -= WebView_NewWindowRequested;
+                _view.Loaded -= WebView_DOMContentLoaded;
                 Debug.WriteLine("Setting initialized - false");
                 _initialized = false;
             }
@@ -149,9 +150,9 @@ namespace Monaco
             if (_view != null)
             {
                 _view.NavigationStarting -= WebView_NavigationStarting;
-                _view.DOMContentLoaded -= WebView_DOMContentLoaded;
                 _view.NavigationCompleted -= WebView_NavigationCompleted;
                 _view.NewWindowRequested -= WebView_NewWindowRequested;
+                _view.Loaded -= WebView_DOMContentLoaded;
                 Debug.WriteLine("Setting initialized - false");
                 _initialized = false;
             }
@@ -161,9 +162,17 @@ namespace Monaco
             if (_view != null)
             {
                 _view.NavigationStarting += WebView_NavigationStarting;
-                _view.DOMContentLoaded += WebView_DOMContentLoaded;
                 _view.NavigationCompleted += WebView_NavigationCompleted;
                 _view.NewWindowRequested += WebView_NewWindowRequested;
+
+                if (_view.IsLoaded)
+                {
+                    WebView_DOMContentLoaded();
+                }
+                else
+                {
+                    _view.Loaded += WebView_DOMContentLoaded;
+                }
 
 #if __WASM__
                 //_view.Source = new System.Uri("ms-appx-web:///Monaco/CodeEditor/CodeEditor.html");

--- a/MonacoEditorComponent/CodeEditor/CodeEditorPresenter.wasm.cs
+++ b/MonacoEditorComponent/CodeEditor/CodeEditorPresenter.wasm.cs
@@ -31,9 +31,6 @@ namespace Monaco
 			//Background = new SolidColorBrush(Colors.Red);
 			_handle = JSObjectHandle.Create(this);
 
-            RaiseDOMContentLoaded();
-
-
             //WebAssemblyRuntime.InvokeJSWithInterop($@"
             //	console.log(""///////////////////////////////// subscribing to DOMContentLoaded - "" + {HtmlId});
 
@@ -65,23 +62,6 @@ namespace Monaco
 
             //	");
         }
-
-        public void RaiseDOMContentLoaded()
-		{
-			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
-			{
-				this.Log().Debug($"RaiseDOMContentLoaded: Handle is null {_handle == null}");
-			}
-
-			if (_handle == null) return;
-
-			if (this.Log().IsEnabled(Microsoft.Extensions.Logging.LogLevel.Debug))
-			{
-				this.Log().Debug($"Raising DOMContentLoaded");
-			}
-
-			_ = Dispatcher.RunAsync(CoreDispatcherPriority.Low, () => DOMContentLoaded?.Invoke(null, null));
-		}
 
 		/// <inheritdoc />
 		public void AddWebAllowedObject(string name, object pObject)
@@ -158,9 +138,6 @@ namespace Monaco
 
 		/// <inheritdoc />
 		public event TypedEventHandler<ICodeEditorPresenter, WebViewNavigationStartingEventArgs> NavigationStarting;
-
-		/// <inheritdoc />
-		public event TypedEventHandler<ICodeEditorPresenter, object> DOMContentLoaded;
 
 		/// <inheritdoc />
 		public event TypedEventHandler<ICodeEditorPresenter, WebViewNavigationCompletedEventArgs> NavigationCompleted; // ignored for now (only focus the editor)

--- a/MonacoEditorComponent/CodeEditor/ICodeEditorPresenter.cs
+++ b/MonacoEditorComponent/CodeEditor/ICodeEditorPresenter.cs
@@ -24,9 +24,6 @@ namespace Monaco
 		/// <summary>Occurs before the WebView navigates to new content.</summary>
 		event TypedEventHandler<ICodeEditorPresenter, WebViewNavigationStartingEventArgs> NavigationStarting;
 
-		/// <summary>Occurs when the WebView has finished parsing the current HTML content.</summary>
-		event TypedEventHandler<ICodeEditorPresenter, object> DOMContentLoaded;
-
 		/// <summary>Occurs when the WebView has finished loading the current content or if navigation has failed.</summary>
 		event TypedEventHandler<ICodeEditorPresenter, WebViewNavigationCompletedEventArgs> NavigationCompleted;
 
@@ -36,7 +33,11 @@ namespace Monaco
 
 		CoreDispatcher Dispatcher { get; }
 
-		IAsyncOperation<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments);
+		bool IsLoaded { get; }
+
+        event RoutedEventHandler Loaded;
+
+        IAsyncOperation<string> InvokeScriptAsync(string scriptName, IEnumerable<string> arguments);
 
 		bool Focus(FocusState state);
 


### PR DESCRIPTION
I wasn't able to isolate a repro outside of NPE, and not 100% clear and what's going on (esp. with VS debugging not being very good on Wasm), but here are the info I could find:

The main issue is that `WebView_DOMContentLoaded` is no longer called with the lifecycle update.

### Previously

1. `WebView_DOMContentLoaded` is getting called from `DOMContentLoaded` event (i.e, via the subscription `_view.DOMContentLoaded += WebView_DOMContentLoaded`)
2. The subscription happens in `CodeEditor.OnApplyTemplate`
3. The event is raised via `RaiseDOMContentLoaded` which is only called in the CodeEditorPresenter's constructor (the raising is dispatched with low priority)

This previously used to work, as `CodeEditor.OnApplyTemplate` was called early enough.

### With updated lifecycle

`OnApplyTemplate` is now happening late enough that the subscription is happening after the event was actually raised. From [Microsoft docs](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.frameworkelement.onapplytemplate?view=winrt-22621):

> OnApplyTemplate is often a more appropriate point to deal with adjustments to the template-created visual tree than is the [Loaded](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.frameworkelement.loaded?view=winrt-22621#windows-ui-xaml-frameworkelement-loaded) event. The [Loaded](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.frameworkelement.loaded?view=winrt-22621#windows-ui-xaml-frameworkelement-loaded) event might occur before the template is applied, and the visual tree might be incomplete as of [Loaded](https://learn.microsoft.com/en-us/uwp/api/windows.ui.xaml.frameworkelement.loaded?view=winrt-22621#windows-ui-xaml-frameworkelement-loaded).

So, what I did here is actually either calling `WebView_DOMContentLoaded` directly in OnApplyTemplate if the presenter is already loaded, or if not, subscribe to loaded.