### PR TITLE
fix: remove redundant DOM Loading subscription affecting Playground

### DIFF
--- a/MonacoEditorComponent/CodeEditor/CodeEditor.cs
+++ b/MonacoEditorComponent/CodeEditor/CodeEditor.cs
@@ -101,9 +101,6 @@ namespace Monaco
                 Decorations.VectorChanged += Decorations_VectorChanged;
                 Markers.VectorChanged += Markers_VectorChanged;
 
-                _view.NewWindowRequested += WebView_NewWindowRequested;
-                _view.Loaded += WebView_DOMContentLoaded;
-
                 Debug.WriteLine("Setting initialized - true");
                 _initialized = true;
 


### PR DESCRIPTION
closes https://github.com/unoplatform/uno/issues/17479